### PR TITLE
Remove base attribute from config to match custom domain

### DIFF
--- a/posts/.vitepress/config.mts
+++ b/posts/.vitepress/config.mts
@@ -6,7 +6,6 @@ export default defineConfig({
   title: 'Triplan eSports',
   description: 'Kaikki ei halua pelata vain sählyä ja padelia',
   lang: 'fi-FI',
-  base: '/esports/',
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [


### PR DESCRIPTION
This PR removes base attribute from the VitePress config so it matches the reserved custom domain for it