### PR TITLE
Add CNAME file for custom domain

### DIFF
--- a/posts/public/CNAME
+++ b/posts/public/CNAME
@@ -1,0 +1,1 @@
+esports.triplan.fi


### PR DESCRIPTION
This PR adds a CNAME file to public-folder that gets copied on build and deployment phase to the root of the server hosting the VitePress page. This CNAME files content matches the custom domain reserved for this VitePress project.